### PR TITLE
Fix/featured projects carousel

### DIFF
--- a/assets/sass/_portfolio.scss
+++ b/assets/sass/_portfolio.scss
@@ -204,7 +204,8 @@ $masonry-prefix: masonry;
 		.#{$portfolio-prefix}-image img {
 			display: block;
 			width: 100%;
-			height: auto;
+			height: $portfolio-carousel-height;
+			object-fit: cover;
 		}
 		&:not(.no-min-height) {
 			min-height: $portfolio-item-min-height;

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -883,6 +883,7 @@ $grid-shuffle-size: 42px;
 $portfolio-item-min-height: 300px;
 $Portfolio_desc-padding: 20px 5px;
 $Portfolio_desc-title-size: 1.1rem;
+$portfolio-carousel-height: 200px;
 
 // Masonry Thumbs: 	;
 $masonry_thumbs-gutter: 1px;

--- a/templates/_elements/portfolio-collection-item.html.twig
+++ b/templates/_elements/portfolio-collection-item.html.twig
@@ -69,8 +69,8 @@
 
 {# Portfolio Collection Item ============================================================ #}
 
-<article class="portfolio-item col-md-4 col-sm-6 col-12{{ categoriesClasses }}">
-    <div class="grid-inner">
+<article class="portfolio-item pt-1 col-md-4 col-sm-6 col-12{{ categoriesClasses }}">
+    <div class="grid-inner shadow">
         <div class="portfolio-image">
 
             {% if isGallery %}


### PR DESCRIPTION
Adapted css for portfolio-item in projects carousel (displayed on "featured projects" section on portfolio main collection page), in order to align items' titles from a column to another.